### PR TITLE
Fix setVelocity infinite regress crash

### DIFF
--- a/bukkit/src/main/java/me/caseload/knockbacksync/player/BukkitPlayer.java
+++ b/bukkit/src/main/java/me/caseload/knockbacksync/player/BukkitPlayer.java
@@ -8,6 +8,7 @@ import com.github.retrooper.packetevents.util.Vector3d;
 import com.google.common.base.Preconditions;
 import me.caseload.knockbacksync.BukkitBase;
 import me.caseload.knockbacksync.Platform;
+import me.caseload.knockbacksync.manager.PlayerDataManager;
 import me.caseload.knockbacksync.world.FoliaWorld;
 import me.caseload.knockbacksync.world.PlatformWorld;
 import me.caseload.knockbacksync.world.SpigotWorld;
@@ -190,7 +191,24 @@ public class BukkitPlayer implements PlatformPlayer {
 
     @Override
     public void setVelocity(Vector3d adjustedVelocity) {
-        bukkitPlayer.setVelocity(new Vector(adjustedVelocity.x, adjustedVelocity.y, adjustedVelocity.z));
+        PlayerData data = PlayerDataManager.getPlayerData(this.getUser());
+
+        if(data == null){
+            // Fallback to normal behavior in the absence of a guard
+            bukkitPlayer.setVelocity(new Vector(adjustedVelocity.x, adjustedVelocity.y, adjustedVelocity.z));
+            return;
+        }
+
+        if(data.isVelocityGuard()){
+            return; // Already applying velocity
+        }
+
+        data.setVelocityGuard(true);
+        try {
+            this.bukkitPlayer.setVelocity(new Vector(adjustedVelocity.x, adjustedVelocity.y, adjustedVelocity.z));
+        } finally {
+            data.setVelocityGuard(false);
+        }
     }
 
     @Override

--- a/common/src/main/java/me/caseload/knockbacksync/listener/PlayerKnockbackListener.java
+++ b/common/src/main/java/me/caseload/knockbacksync/listener/PlayerKnockbackListener.java
@@ -21,6 +21,9 @@ public abstract class PlayerKnockbackListener {
         PlayerData victimPlayerData = PlayerDataManager.getPlayerData(user);
         if (victimPlayerData == null)
             return;
+        if (victimPlayerData.isVelocityGuard()) { // Prevent velocity setter from looping infinitely
+            return;
+        }
 
         if (victimPlayerData.getNotNullPing() < PlayerData.PING_OFFSET)
             return;
@@ -50,6 +53,8 @@ public abstract class PlayerKnockbackListener {
         else
             return;
 
+        victimPlayerData.setVelocityGuard(true);;
         victim.setVelocity(adjustedVelocity);
+        victimPlayerData.setVelocityGuard(false);
     }
 }

--- a/common/src/main/java/me/caseload/knockbacksync/player/PlayerData.java
+++ b/common/src/main/java/me/caseload/knockbacksync/player/PlayerData.java
@@ -47,6 +47,8 @@ public class PlayerData {
     public static final long PING_OFFSET = 25;
 
     private static Field playerField;
+    @Getter @Setter
+    private boolean velocityGuard = false; // Used to prevent infinite recursion while setting velocity
 
     public final Queue<Pair<Integer, Long>> transactionsSent = new ConcurrentLinkedQueue<>();
     public final Queue<Pair<Long, Long>> keepaliveMap = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
Added a guard flag to BukkitPlayer.setVelocity and PlayerKnockbackListener.onPlayerVelocity.
Hopefully ts guard flag will stop ts plugin from looping endlessly and crashing the server