### PR TITLE
Fix obscure player adding exception

### DIFF
--- a/KnockbackSync.iml
+++ b/KnockbackSync.iml
@@ -5,6 +5,7 @@
       <configuration>
         <autoDetectTypes>
           <platformType>SPIGOT</platformType>
+          <platformType>ADVENTURE</platformType>
         </autoDetectTypes>
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>

--- a/KnockbackSync.iml
+++ b/KnockbackSync.iml
@@ -5,7 +5,6 @@
       <configuration>
         <autoDetectTypes>
           <platformType>SPIGOT</platformType>
-          <platformType>ADVENTURE</platformType>
         </autoDetectTypes>
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>

--- a/common/src/main/java/me/caseload/knockbacksync/manager/PlayerDataManager.java
+++ b/common/src/main/java/me/caseload/knockbacksync/manager/PlayerDataManager.java
@@ -21,7 +21,11 @@ public class PlayerDataManager {
         return playerDataMap.get(user);
     }
 
-    public static void addPlayerData(@NotNull User user, @NotNull PlatformPlayer platformPlayer) {
+    public static void addPlayerData(@Nullable User user, @Nullable PlatformPlayer platformPlayer) {
+        if (user == null || platformPlayer == null) {
+            return;
+        }
+
         if (!shouldExempt(platformPlayer.getUUID())) {
             PlayerData playerData = new PlayerData(user, platformPlayer);
             playerDataMap.put(user, playerData);


### PR DESCRIPTION
I haven't found an instance where this incorrectly passes for valid users in effectively any/all scenarios; however, I have identified cases where this incorrectly passes for simulated players (fake players)